### PR TITLE
WIP: Combines cellprofiler output after run

### DIFF
--- a/gc3apps/gcp_pipeline.py
+++ b/gc3apps/gcp_pipeline.py
@@ -131,7 +131,6 @@ class GCellprofilerPipeline(StagedTaskCollection):
     Staged collection:
     Step1: Generate groups .json file, used to get index size of batch images
     Step2: generate batch and run cellprofiler in batch mode for each batch
-    Step3: combine the output into 1 output folder
     """
     def __init__(self, cppipe, input_folder, output_folder, chunks, plugins, **extra_args):
 


### PR DESCRIPTION
This combines all the output folder into the parent output folder
by:
a) Copying the files, preserving the subfolder structures
b) In case of files being duplicated in different output folders:
	- if the file is a .csv: append the files to each other
	- else: don't copy the file

TODO:
- Currently, this copies the files - if the code is OK the files should
	rather be moved to avoid duplicated files.
- The temporary output, output_*, could also be removed in the cleanup
	process.
- How to deal with files present in multiple output folders with
identical names? In a non-parallelized version, these files would
overwrite each other. I would also replicate that behavior while
issuing a warning.

This is now working. Could I have your opinion on my implementation and your thoughts on the TODO?